### PR TITLE
Define DOMPDF_ENABLE_AUTOLOAD once

### DIFF
--- a/src/PdfServiceProvider.php
+++ b/src/PdfServiceProvider.php
@@ -24,7 +24,7 @@ class PdfServiceProvider extends ServiceProvider
         });
 
         $this->app->bind('Vsmoraes\Pdf\Pdf', function() {
-            define('DOMPDF_ENABLE_AUTOLOAD', false);
+            $this->define("DOMPDF_ENABLE_AUTOLOAD", false);
 
             require_once base_path() . '/vendor/dompdf/dompdf/dompdf_config.inc.php';
 
@@ -40,5 +40,18 @@ class PdfServiceProvider extends ServiceProvider
     public function provides()
     {
         return ['Vsmoraes\Pdf\Pdf'];
+    }
+
+    /**
+     * Define a value, if not already defined
+     *
+     * @param string $name
+     * @param string $value
+     */
+    protected function define($name, $value)
+    {
+        if (! defined($name)) {
+            define($name, $value);
+        }
     }
 }


### PR DESCRIPTION
Guard against the following possible error:
[ErrorException]
  Constant DOMPDF_ENABLE_AUTOLOAD already defined
